### PR TITLE
fix: DateTime64 on MaterializedPostgreSQL

### DIFF
--- a/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
+++ b/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
@@ -326,6 +326,15 @@ ASTPtr StorageMaterializedPostgreSQL::getColumnDeclaration(const DataTypePtr & d
         if (which.isDecimal256())
             return make_decimal_expression("Decimal256");
     }
+    
+    if (which.isDateTime64()){
+        auto ast_expression = std::make_shared<ASTFunction>();
+
+        ast_expression->name = "DateTime64";
+        ast_expression->arguments = std::make_shared<ASTExpressionList>();
+        ast_expression->arguments->children.emplace_back(std::make_shared<ASTLiteral>(UInt32(6)));
+        return ast_expression;
+    }
 
     return std::make_shared<ASTIdentifier>(data_type->getName());
 }

--- a/src/Storages/StoragePostgreSQL.cpp
+++ b/src/Storages/StoragePostgreSQL.cpp
@@ -236,7 +236,7 @@ public:
         else if (which.isDateTime())                     nested_column = ColumnUInt32::create();
         else if (which.isDateTime64())
         {
-            nested_column = ColumnDecimal<Decimal64>::create(0, 6);
+            nested_column = ColumnDecimal<DateTime64>::create(0, 6);
         }
         else if (which.isDecimal32())
         {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature
- Bug Fix
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Other
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
